### PR TITLE
Add JavaScript-based doctor search

### DIFF
--- a/whopays/static/css/wp.css
+++ b/whopays/static/css/wp.css
@@ -25,3 +25,26 @@ table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):after {
     content: " \25B4\25BE" 
 }
 
+/* --------
+Doctor search
+----------*/
+.search-control {
+  background: #F7F3ED;
+  border-radius: 6px 6px 0 0;
+  padding: 1em;
+}
+
+.search-control label {
+  margin: 0
+}
+
+.search-control input[type=text] {
+  padding: 0.33em 0.5em;
+  width: 20em;
+  max-width: 80%;
+}
+
+#no-results {
+  background: #F7F3ED;
+  display: none;
+}

--- a/whopays/static/main.js
+++ b/whopays/static/main.js
@@ -1,0 +1,70 @@
+let search = {
+  rows: [],
+  matches: []
+}
+  
+search.init = function(searchElement, tableElement) {
+  this.searchElement = searchElement;
+  this.tableElement = tableElement;
+  this.noResultsElement = document.getElementById('no-results');
+  this.processRows();
+  this.addEvents();
+}
+
+search.processRows = function() {
+  let rowElements = this.tableElement.querySelectorAll('tr.doctor');
+  for(let i = 0; i < rowElements.length; i++) {
+    let row = rowElements[i];
+    let fields = row.querySelectorAll('td');
+    let name = fields[0].innerText;
+    let position = fields[3].innerText;
+    this.rows.push({
+      text: name + position,
+      element: row
+    });
+  }
+}
+  
+search.addEvents = function() {
+  this.searchElement.addEventListener('keyup', (event) => {
+    this.doSearch(event.target.value);
+  });
+  this.searchElement.addEventListener('change', (event) => {
+    this.doSearch(event.target.value);
+  });
+}
+  
+search.searchRows = function(string) {
+  string = string.trim().toLowerCase();
+  let matches = [];
+  for(let i = 0; i < this.rows.length; i++) {
+    let target = this.rows[i].text.trim().toLowerCase();
+    if ( target.indexOf(string) == -1 ) {
+      this.rows[i].element.style.display = "none";
+    } else {
+      this.rows[i].element.style.display = "table-row";
+      matches.push(i);
+    };
+  }
+  if( matches.length == 0 ) {
+    this.noResultsElement.style.display = "table-row";
+  } else {
+    this.noResultsElement.style.display = "none";
+  }
+}
+  
+search.doSearch = function(keyword) {
+  if ( this.searchTimeoutID ) {
+    window.clearTimeout(this.searchTimeoutID);
+  }
+  this.searchElement.classList.add('loading');
+  this.searchTimeoutID = window.setTimeout(()=>{
+    this.searchRows(keyword);
+    this.searchTimeoutID = null;
+  }, 200);
+}
+
+search.init(
+  document.getElementById('search-field'),
+  document.getElementById('doctor-table'),
+);

--- a/whopays/templates/baser.html
+++ b/whopays/templates/baser.html
@@ -81,12 +81,12 @@
     <script src="https://code.jquery.com/jquery.js"></script>
     <script src="{% static 'css/lib/bootstrap/js/bootstrap.js' %}"></script>
     <script src="{% static 'sorttable.js' %}"></script>
-    <script>
+    <script src="{% static 'main.js' %}"></script>    <script>
 	  // Activates the Carousel
 	  $('.carousel').carousel({
 		interval: 5000
 	  })
-	</script>
+	   </script>
     {% block extrajs %}
 
     {% endblock %}

--- a/whopays/templates/doctors/doctor_list.html
+++ b/whopays/templates/doctors/doctor_list.html
@@ -6,7 +6,13 @@
         <hr>
         <h2 class="intro-text text-center">Declarations so far</h2>
         <hr />
-        <table class="table sortable">
+        <div class="search-control">
+          <label>
+            Search for a doctor
+            <input type="text" id="search-field" placeholder="e.g. by surname or where they work" />
+          </label>
+        </div>
+        <table class="table sortable" id="doctor-table">
           <tr>
             <th>Name</th>
             <th>GMC</th>
@@ -14,7 +20,7 @@
             <th>Primary Employer</th>
           </tr>
           {% for doctor in doctors %}
-            <tr>
+            <tr class="doctor">
               <td>
                 <a href="{{doctor.get_absolute_url}}">
                   {{ doctor.name }}
@@ -25,6 +31,7 @@
               <td>{{doctor.primary_employer}}</td>
             </tr>
           {% endfor %}
+          <tr id="no-results"><td colspan="4">No results found</td></tr>
         </table>
       </div>
     </div>


### PR DESCRIPTION
This PR adds a JavaScript-based in-page search to the doctors page.

It searches through the name and employer of each doctor for a string entered by the user and then selectively shows or hides relevant rows.